### PR TITLE
elasticsearch basic authentication support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ Basically Automaton Engine is ***all*** about the following:
 * `notify` - Send a Rocket Chat webhook.
 * `awx` - Calls an Ansible AWX API endpoint.
 
+## Installation
+
+Install via pip:
+```
+$ pip install automaton-engine
+```
+
+Build from source:
+```
+$ git clone https://github.com/jgericke/automaton_engine.git
+$ python setup.py install
+```
+
+Run tests:
+```
+$ python setup.py test
+```
+
+
 ## Example Workflow
 
     1. Create an Elasticsearch query to read the number of orders being processed (assuming you have some sort of order system thats sending metrics to Elasticsearch...)
@@ -78,8 +97,14 @@ export AUTOMATON_ENGINE_CONFIG='{
             "name": "my_neat_automaton",
             "enabled": True,
             "runonce": False,
-            "elasticsearch_url": "http://my.elasticsearch:9200",
-            "elasticsearch_timeout": 10,
+            "elasticsearch": {
+                "url": "https://http://my.elasticsearch:9200",
+                "timeout": 10,
+                "auth": {
+                    "username": "es_user",
+                    "password": "es_pass",
+                },
+            },
             "elasticsearch_query": {
                 "query_interval": 5,
                 "query_endpoint": "/_search",
@@ -137,7 +162,29 @@ export AUTOMATON_ENGINE_CONFIG='{
 }'
 ```
 
+### Elasticsearch Authentication
 
+Automaton now supports basic authentication for elasticsearch, to configure it add an "auth" section to your automaton configuration as per below:
+
+```
+            "elasticsearch": {
+                "url": "https://http://my.elasticsearch:9200",
+                "timeout": 10,
+                "auth": {
+                    "username": "es_user",
+                    "password": "es_pass",
+                },
+            },
+```
+
+No elasticsearch authentication? No problem! Simply remove the auth stanza:
+
+```
+            "elasticsearch": {
+                "url": "https://http://my.elasticsearch:9200",
+                "timeout": 10,
+            },
+```
 
 #### Original Author(s)
 

--- a/automaton_engine/runner.py
+++ b/automaton_engine/runner.py
@@ -32,10 +32,7 @@ def runner(argv=None):
                         "runonce"
                     ],
                     biome.AUTOMATON_ENGINE.get_dict("config")["automatons"][cfg][
-                        "elasticsearch_url"
-                    ],
-                    biome.AUTOMATON_ENGINE.get_dict("config")["automatons"][cfg][
-                        "elasticsearch_timeout"
+                        "elasticsearch"
                     ],
                     biome.AUTOMATON_ENGINE.get_dict("config")["automatons"][cfg][
                         "elasticsearch_query"

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,24 @@ Basically Automaton Engine is ***all*** about the following:
 * `notify` - Send a Rocket Chat webhook.
 * `awx` - Calls an Ansible AWX API endpoint.
 
+## Installation
+
+Install via pip:
+```
+$ pip install automaton-engine
+```
+
+Build from source:
+```
+$ git clone https://github.com/jgericke/automaton_engine.git
+$ python setup.py install
+```
+
+Run tests:
+```
+$ python setup.py test
+```
+
 ## Example Workflow
 
     1. Create an Elasticsearch query to read the number of orders being processed (assuming you have some sort of order system thats sending metrics to Elasticsearch...)
@@ -74,8 +92,14 @@ export AUTOMATON_ENGINE_CONFIG='{
             "name": "my_neat_automaton",
             "enabled": True,
             "runonce": False,
-            "elasticsearch_url": "http://my.elasticsearch:9200",
-            "elasticsearch_timeout": 10,
+            "elasticsearch": {
+                "url": "https://http://my.elasticsearch:9200",
+                "timeout": 10,
+                "auth": {
+                    "username": "es_user",
+                    "password": "es_pass",
+                },
+            },
             "elasticsearch_query": {
                 "query_interval": 5,
                 "query_endpoint": "/_search",
@@ -133,6 +157,29 @@ export AUTOMATON_ENGINE_CONFIG='{
 }'
 ```
 
+### Elasticsearch Authentication
+
+Automaton now supports basic authentication for elasticsearch, to configure it add an "auth" section to your automaton configuration as per below:
+
+```
+            "elasticsearch": {
+                "url": "https://http://my.elasticsearch:9200",
+                "timeout": 10,
+                "auth": {
+                    "username": "es_user",
+                    "password": "es_pass",
+                },
+            },
+```
+
+No elasticsearch authentication? No problem! Simply remove the auth stanza:
+
+```
+            "elasticsearch": {
+                "url": "https://http://my.elasticsearch:9200",
+                "timeout": 10,
+            },
+```
 
 
 #### Original Author(s)

--- a/samples/sample-automaton-orders.env
+++ b/samples/sample-automaton-orders.env
@@ -1,0 +1,73 @@
+export AUTOMATON_ENGINE_LOGLEVEL='INFO'
+export AUTOMATON_ENGINE_CONFIG='{ 
+    "automatons": [
+        {
+            "name": "auto_orders_scaler",
+            "enabled": True,
+            "runonce": False,
+            "elasticsearch": {
+                "url": "https://sample.elasticsearch.url",
+                "timeout": 10,
+                "auth": {
+                    "username": "es_user",
+                    "password": "es_passw",
+                },
+            },
+            "elasticsearch_query": {
+                "query_interval": 10,
+                "query_endpoint": "/_search",
+                "query_type": "aggregations",
+                "query_name": "order_qty",
+                "query_payload": {
+                    "size": 0,
+                    "query": {
+                        "range": {
+                            "@timestamp": {
+                                "gte": "now-1m"
+                            }
+                        }
+                    },
+                    "aggregations": {
+                        "order_qty": {
+                            "terms": {
+                                "field": "tags.keyword",
+                                "include": "order_succeeded",
+                                "min_doc_count": 3
+                            }
+                        }
+                    }
+                },
+                "query_response_mapping": { 
+                        "key": "order_state", 
+                        "doc_count": "order_rate"
+                }
+            },
+            "actions": [
+                {
+                    "name": "notify.rocketchat_webhook",
+                    "backoff_seconds": 60, 
+                    "parameters": {
+                        "rocketchat_webhook": "https://sample.rocketchat.url/hooks/hook-id",
+                        "rocketchat_message": "@here Good news everyone! We are processing an unusually high volume of orders",
+                        "rocketchat_timeout": 10
+                    }
+                },
+                {
+                    "name": "awx.api_call",
+                    "backoff_seconds": 60,
+                    "parameters": {
+                        "awx_url": "https://sample.awx.url",
+                        "awx_context": "/api/v2/job_templates/jobid/launch/",
+                        "awx_timeout": 20,
+                        "awx_auth": {
+                            "username": "awx_user",
+                            "password": "awx_pass"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}'
+automaton-engine
+

--- a/tests/test_automaton_engine.py
+++ b/tests/test_automaton_engine.py
@@ -21,8 +21,11 @@ def automaton_engine_defaults():
     automaton_engine_name = "test_automaton_engine"
     automaton_engine_enabled = True
     automaton_engine_runonce = True
-    automaton_engine_elasticsearch_url = "http://es.loc:9200"
-    automaton_engine_elasticsearch_timeout = 1
+    automaton_engine_elasticsearch = {
+        "url": "http://es.loc:9200",
+        "timeout": 1,
+        "auth": {"username": "es_user", "password": "es_pass"},
+    }
     automaton_engine_elasticsearch_query = {
         "query_interval": 5,
         "query_endpoint": "/_search",
@@ -68,8 +71,7 @@ def automaton_engine_defaults():
         automaton_engine_name,
         automaton_engine_enabled,
         automaton_engine_runonce,
-        automaton_engine_elasticsearch_url,
-        automaton_engine_elasticsearch_timeout,
+        automaton_engine_elasticsearch,
         automaton_engine_elasticsearch_query,
         automaton_engine_actions,
     )
@@ -81,7 +83,9 @@ class TestAutomatonEngine(object):
         assert isinstance(automaton_engine_defaults.name, str)
         assert isinstance(automaton_engine_defaults.enabled, bool)
         assert isinstance(automaton_engine_defaults.runonce, bool)
-        assert isinstance(automaton_engine_defaults.es_url, str)
+        assert isinstance(automaton_engine_defaults.elasticsearch, dict)
+        assert isinstance(automaton_engine_defaults.elasticsearch["url"], str)
+        assert isinstance(automaton_engine_defaults.elasticsearch["timeout"], int)
         assert isinstance(automaton_engine_defaults.es_query, dict)
         assert isinstance(automaton_engine_defaults.actions, list)
 


### PR DESCRIPTION
Added basicauth support for elasticsearch, which can be added or removed from the AUTOMATON_ENGINE_CONFIG as needed

`
            "elasticsearch": {
                "url": "https://http://my.elasticsearch:9200",
                "timeout": 10,
                "auth": {
                    "username": "es_user",
                    "password": "es_pass",
                },
'